### PR TITLE
Скрипт для запуска тестов ДЗ локально + инструкция

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.tmp
 *.pyc
 __pycache__
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # otus-platform-tests
+
+# Запуск тестов в локальном окружении
+
+## Prerequisites
+
+Рекомендуется запускать на виртуальной машине для изоляции окружения.
+
+Протестировано на `Ubuntu 18.04` установленной на виртуальную машину `VirtualBox 6.0.8`. Хост ОС: `macOs Mojave 10.14.6`
+
+Параметры виртуальной машины: `CPU 4 cores, RAM 4096 MB`
+
+*Важно:* При использовании менее 2х CPU cores таймаутов в тестах не хватает и происходят ложные падения!
+
+## Как запустить тесты локально
+
+ 1. Клоним репозиторий с тестами `otus-platform-tests` : `git clone https://github.com/express42/otus-platform-tests.git`
+ 2. Переходим в ветку тестов для группы `2019-06`: `git checkout 2019-06`
+ 3. Скрипт можно запустить 2мя способами:
+    3.1 Запуск с параметрами: `./local-run.sh {абсолютный-путь-к-локальной-папке-[gitname]_platform} {имя-папки-с-дз}`.
+    Например: `./local-run.sh /Users/ivan.ivanov/Documents/src/ivan_platform kubernetes-networks`. Таким образом мы запустим
+    локально тестирование Домашней Работы №3 по сетям.
+    3.2 Запуск скрипта без параметров и указание путей в процессе выполенния: `./local-run.sh`.
+    В результате скрипт попросит указать абсолютный путь к локальной папке {gitname}_platform: `Your local platform folder (something like /Users/sergii.sinienok/src/{gitname}_platform):`
+    И название папки с ДЗ, которое хотим протестировать: `Homework dir you want me to check (kubernetes-intro or others):`
+    Скрипт валидируе базовые ошибки пользовательского ввода. Читайте внимательно сообщения.
+
+# Troubleshooting
+ 1. Ошибка `Error: a cluster with the name "kind" already exists` - выполните `kind delete cluster` для починки. Внимание!!! Это удалит дефолтный kind кластер с вашего локального окружения! Будьте бдительны!!!

--- a/local-run.sh
+++ b/local-run.sh
@@ -1,0 +1,36 @@
+
+echo "Howdy! I will run [otus-platform-tests] locally for you.\n"
+
+dirtocheck=""
+platformdir=""
+hwdir=""
+
+if [[ ! -d $1 || "$2" == "" ]]; then
+    echo "You'll supposed to point me in, I'll need to know where to start.\n"
+
+    read -p "Your local platform folder (something like $HOME/src/{gitname}_platform):" platformdir
+
+    if [ ! -d $platformdir ]; then
+        echo "Does not look like a valid folder. You can do better!"
+        exit 1
+    fi
+
+    read -p "Homework dir you want me to check (kubernetes-intro or others):" hwdir
+
+    if [ "$hwdir" == "" ]; then
+        echo "No in - no out! Point me somewhere to do the job."
+        exit 1
+    fi
+
+    dirtocheck="$platformdir/$hwdir"
+else
+    hwdir="$2"
+    dirtocheck="$1/$hwdir"
+fi
+
+echo "\nYou pointed me here [$dirtocheck]. I will obey! \n"
+
+cd $dirtocheck
+export TRAVIS_BRANCH=$(echo $hwdir | tr -d '\r')
+
+curl https://raw.githubusercontent.com/express42/otus-platform-tests/2019-06/run.sh | bash

--- a/local-run.sh
+++ b/local-run.sh
@@ -1,37 +1,38 @@
-
-printf "Howdy! I will run [otus-platform-tests] locally for you.\n"
-
-dirtocheck=""
+#!/bin/bash
+echo "Howdy! I will run [otus-platform-tests] locally for you."
+echo
 platformdir=""
 hwdir=""
 
 if [[ ! -d $1 || "$2" == "" ]]; then
-    printf "You'll supposed to point me in, I'll need to know where to start.\n"
+    echo "You'll supposed to point me in, I'll need to know where to start."
 
     read -p "Your local platform folder (something like $HOME/src/{gitname}_platform):" platformdir
 
-    if [ ! -d $platformdir ]; then
-        printf "Does not look like a valid folder. You can do better!"
+    if [ ! -d "$platformdir" ]; then
+        echo "Does not look like a valid folder. You can do better!"
         exit 1
     fi
 
     read -p "Homework dir you want me to check (kubernetes-intro or others):" hwdir
 
     if [ "$hwdir" == "" ]; then
-        printf "No in - no out! Point me somewhere to do the job."
+        echo "No in - no out! Point me somewhere to do the job."
         exit 1
     fi
-
-    dirtocheck="$platformdir/$hwdir"
 else
     platformdir="$1"
     hwdir="$2"
-    dirtocheck="$platformdir/$hwdir"
 fi
 
-printf "\nYou pointed me here [$platformdir] to check [$hwdir]. I will obey! \n"
-printf "\n"
-cd $platformdir
-export TRAVIS_BRANCH=$(echo $hwdir | tr -d '\r')
+printf "\nYou pointed me here [%s] to check [%s]. I will obey! \n" "$platformdir" "$hwdir"
+echo
 
-curl https://raw.githubusercontent.com/express42/otus-platform-tests/2019-06/run.sh | bash
+pathtorunsh="$PWD/run.sh"
+
+cd "$platformdir" || exit 1
+
+TRAVIS_BRANCH=$(echo "$hwdir" | tr -d '\r')
+export TRAVIS_BRANCH
+
+bash "$pathtorunsh"

--- a/local-run.sh
+++ b/local-run.sh
@@ -1,36 +1,37 @@
 
-echo "Howdy! I will run [otus-platform-tests] locally for you.\n"
+printf "Howdy! I will run [otus-platform-tests] locally for you.\n"
 
 dirtocheck=""
 platformdir=""
 hwdir=""
 
 if [[ ! -d $1 || "$2" == "" ]]; then
-    echo "You'll supposed to point me in, I'll need to know where to start.\n"
+    printf "You'll supposed to point me in, I'll need to know where to start.\n"
 
     read -p "Your local platform folder (something like $HOME/src/{gitname}_platform):" platformdir
 
     if [ ! -d $platformdir ]; then
-        echo "Does not look like a valid folder. You can do better!"
+        printf "Does not look like a valid folder. You can do better!"
         exit 1
     fi
 
     read -p "Homework dir you want me to check (kubernetes-intro or others):" hwdir
 
     if [ "$hwdir" == "" ]; then
-        echo "No in - no out! Point me somewhere to do the job."
+        printf "No in - no out! Point me somewhere to do the job."
         exit 1
     fi
 
     dirtocheck="$platformdir/$hwdir"
 else
+    platformdir="$1"
     hwdir="$2"
-    dirtocheck="$1/$hwdir"
+    dirtocheck="$platformdir/$hwdir"
 fi
 
-echo "\nYou pointed me here [$dirtocheck]. I will obey! \n"
-
-cd $dirtocheck
+printf "\nYou pointed me here [$platformdir] to check [$hwdir]. I will obey! \n"
+printf "\n"
+cd $platformdir
 export TRAVIS_BRANCH=$(echo $hwdir | tr -d '\r')
 
 curl https://raw.githubusercontent.com/express42/otus-platform-tests/2019-06/run.sh | bash


### PR DESCRIPTION
# Запуск тестов в локальном окружении

## Prerequisites

Рекомендуется запускать на виртуальной машине для изоляции окружения.

Протестировано на `Ubuntu 18.04` установленной на виртуальную машину `VirtualBox 6.0.8`. Хост ОС: `macOs Mojave 10.14.6`

Параметры виртуальной машины: `CPU 4 cores, RAM 4096 MB`

*Важно:* При использовании менее 2х CPU cores таймаутов в тестах не хватает и происходят ложные падения!

## Как запустить тесты локально

 1. Клоним репозиторий с тестами `otus-platform-tests` : `git clone https://github.com/express42/otus-platform-tests.git`
 2. Переходим в ветку тестов для группы `2019-06`: `git checkout 2019-06`
 3. Скрипт можно запустить 2мя способами:
    3.1 Запуск с параметрами: `./local-run.sh {абсолютный-путь-к-локальной-папке-[gitname]_platform} {имя-папки-с-дз}`.
    Например: `./local-run.sh /Users/ivan.ivanov/Documents/src/ivan_platform kubernetes-networks`. Таким образом мы запустим
    локально тестирование Домашней Работы №3 по сетям.
    3.2 Запуск скрипта без параметров и указание путей в процессе выполенния: `./local-run.sh`.
    В результате скрипт попросит указать абсолютный путь к локальной папке {gitname}_platform: `Your local platform folder (something like /Users/sergii.sinienok/src/{gitname}_platform):`
    И название папки с ДЗ, которое хотим протестировать: `Homework dir you want me to check (kubernetes-intro or others):`
    Скрипт валидируе базовые ошибки пользовательского ввода. Читайте внимательно сообщения.

# Troubleshooting
 1. Ошибка `Error: a cluster with the name "kind" already exists` - выполните `kind delete cluster` для починки. Внимание!!! Это удалит дефолтный kind кластер с вашего локального окружения! Будьте бдительны!!!